### PR TITLE
moderating the "number of download" statement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ Kyle Kelley is a programmer, sometimes mathematician, oftentimes ops. He works f
 
 <img class="headshot" src="headshots/laurent_gautier.jpg" width="180px"/>
 
-Laurent Gautier is a Senior Investigator at Novartis Institutes for BioMedical Research.  He is a long-time user of R and original core member of the bioconductor project, the lead of the [Python-R bridge](https://pypi.python.org/pypi/rpy2) (60,000 downloads/month!), and he wrote the first [Julia-R bridge](https://github.com/lgautier/Rif.jl).
+Laurent Gautier is a Senior Investigator at Novartis Institutes for BioMedical Research.  He is a long-time user of R and original core member of the bioconductor project, the lead of the [Python-R bridge](https://pypi.python.org/pypi/rpy2) (up to 60,000 downloads/month!), and he wrote the first [Julia-R bridge](https://github.com/lgautier/Rif.jl).
 
 # Mattias Bussonnier
 ## Jupyter Project / UC Berkeley


### PR DESCRIPTION
The number of downloads on pypi is a bit of a rollercoaster... depending, among other things, on cluster farms suddenly needing it or whether the download count on pypi is broken or not (currently it is)
